### PR TITLE
Renamed files return the old file path instead of the new path

### DIFF
--- a/lib/githooks/repository/diff_index_entry.rb
+++ b/lib/githooks/repository/diff_index_entry.rb
@@ -11,7 +11,7 @@ module GitHooks
       (?<new_sha>[a-f\d]+)\s
       (?<change_type>.)
       (?:(?<score>\d+)?)\s
-      (?<file_path>\S+)
+      (?<file_path>\S+)\s?
       (?<rename_path>\S+)?
     }xi unless defined? DIFF_STRUCTURE_REGEXP
 


### PR DESCRIPTION
Tracked this down to the regex used to parse the git information. Currently it doesn't check for a space between the old and new paths so the new path is always nil
