### PR TITLE
Error when attaching if hooks directory doesn't exist

### DIFF
--- a/lib/githooks/runner.rb
+++ b/lib/githooks/runner.rb
@@ -99,10 +99,10 @@ module GitHooks
       gitrunner ||= (GitHooks::BIN_PATH + 'githooks-runner').realpath
 
       # When repos are cloned, sometimes the hooks directory isn't created
-      FileUtils.mkdir(@repository.hooks) unless File.directory?(@repository.hooks)
+      repository.hooks.mkdir unless repository.hooks.directory?
 
       hook_phases.each do |hook|
-        hook = (@repository.hooks + hook).to_s
+        hook = (repository.hooks + hook).to_s
         puts "Linking #{gitrunner} -> #{hook}" if GitHooks.verbose
         FileUtils.ln_sf gitrunner.to_s, hook
       end

--- a/lib/githooks/runner.rb
+++ b/lib/githooks/runner.rb
@@ -98,6 +98,9 @@ module GitHooks
       gitrunner ||= SystemUtils.which('githooks-runner')
       gitrunner ||= (GitHooks::BIN_PATH + 'githooks-runner').realpath
 
+      # When repos are cloned, sometimes the hooks directory isn't created
+      FileUtils.mkdir(@repository.hooks) unless File.directory?(@repository.hooks)
+
       hook_phases.each do |hook|
         hook = (@repository.hooks + hook).to_s
         puts "Linking #{gitrunner} -> #{hook}" if GitHooks.verbose


### PR DESCRIPTION
When a repo is cloned, the hooks directory won't be created in some cases. This causes the attach command to fail with a "Errno::ENOENT: No such file or directory" error.