### PR TITLE
Loosened some dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 source "http://rubygems.org"
 
 gemspec
-
-if RUBY_ENGINE == 'ruby'
-  gem 'parser', "~> #{RUBY_VERSION}.0"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,23 +2,25 @@ PATH
   remote: .
   specs:
     rabbitt-githooks (1.6.1)
-      rainbow (~> 2.0.0)
+      rainbow (>= 2.0.0, < 4.0)
       thor (~> 0.19.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    ast (2.1.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
-    diff-lcs (1.2.5)
-    docile (1.1.5)
-    json (1.8.3)
-    parser (2.2.2.6)
-      ast (>= 1.1, < 3.0)
-    powerpack (0.1.1)
-    rainbow (2.0.0)
-    rake (10.4.2)
+    ast (2.4.0)
+    diff-lcs (1.3)
+    docile (1.3.1)
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
+    json (2.1.0)
+    json (2.1.0-java)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rake (10.5.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -27,31 +29,34 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.4)
-    rubocop (0.34.2)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.2.5, < 3.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.4)
-    ruby-lint (2.0.5)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-lint (2.3.1)
       parser (~> 2.2)
       slop (~> 3.4, >= 3.4.7)
-    ruby-progressbar (1.7.5)
-    simplecov (0.10.0)
-      docile (~> 1.1.0)
-      json (~> 1.8)
+    ruby-progressbar (1.9.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
     slop (3.6.0)
-    thor (0.19.1)
-    yard (0.8.7.6)
+    thor (0.19.4)
+    unicode-display_width (1.4.0)
+    yard (0.9.15)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
   bundler (~> 1.3)
-  parser (~> 2.2.2.0)
   rabbitt-githooks!
   rake (~> 10.1)
   rspec (~> 2.14)
@@ -61,4 +66,4 @@ DEPENDENCIES
   yard (~> 0.7)
 
 BUNDLED WITH
-   1.10.6
+   1.15.2

--- a/rabbitt-githooks.gemspec
+++ b/rabbitt-githooks.gemspec
@@ -38,7 +38,7 @@ begin
     spec.require_paths    = ['lib']
     spec.extra_rdoc_files = ['README.md', 'LICENSE.txt']
 
-    spec.add_dependency 'rainbow', '~> 2.0.0'
+    spec.add_dependency 'rainbow', '>= 2.0.0', '< 4.0'
     spec.add_dependency 'thor', '~> 0.19.1'
 
     spec.add_development_dependency 'rake', '~> 10.1'


### PR DESCRIPTION
Newer versions of rubocop have dependencies on newer versions of these dependencies. Also, the parser gem does not release a version for every patch version of ruby now so I removed the requirements for that gem (for example there isn't a parser 3.3.6.0 to match mri 3.3.6)